### PR TITLE
users shouldn't call npm or bower directly

### DIFF
--- a/Part3/hub install.ipynb
+++ b/Part3/hub install.ipynb
@@ -205,8 +205,7 @@
    "source": [
     "Install JupyterHub’s JavaScript dependencies.  First navigate into the freshly cloned repository, `cd jupyterhub`.  Then run:\n",
     "\n",
-    "    npm install\n",
-    "    $(npm bin)/bower install"
+    "    python3 setup.py js css"
    ]
   },
   {


### PR DESCRIPTION
technically, this entire step should be unnecessary, as `pip install .` implies it. But it's probably helpful for it to be explicit.
